### PR TITLE
update links for Threat Dragon OWASP project pages

### DIFF
--- a/tab_resources.md
+++ b/tab_resources.md
@@ -13,7 +13,7 @@ The best resource to start learning about threat modeling or improving your exis
 ## Related OWASP Projects 
 
   - [OWASP Threat Model Cookbook](https://owasp.org/www-project-threat-model-cookbook/)
-  - [OWASP Threat Dragon](https://docs.threatdragon.org/)
+  - [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)
   - [OWASP PyTM](https://owasp.org/www-project-pytm/)
   - [OWASP Threatspec](https://owasp.org/www-project-threatspec/)
   - [OWASP Ontology Driven Threat Modeling](https://owasp.org/www-project-ontology-driven-threat-modeling-framework/)

--- a/tab_threatmodeling.md
+++ b/tab_threatmodeling.md
@@ -96,6 +96,6 @@ and justifies them with either sub-claims or evidence.
 
 ## Threat Modeling Tooling
 
-There is a wide variety of tools that can support threat modeling, including [OWASP Threat Dragon](https://docs.threatdragon.org/), [OWASP pytm](https://owasp.org/www-project-pytm/), and [OWASP Threatspec](https://owasp.org/www-project-threatspec/). 
+There is a wide variety of tools that can support threat modeling, including [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/), [OWASP pytm](https://owasp.org/www-project-pytm/), and [OWASP Threatspec](https://owasp.org/www-project-threatspec/). 
 
 There are also a number of other tools available, both Open Source and commercial.


### PR DESCRIPTION
The links for Threat  Dragon have been updated to point to the OWASP project area, rather than the Threat Dragon docs site. This keeps Threat Dragon in line with the links to other OWASP projects