### PR TITLE
Clarify canonical entry point for Threat Modeling resources

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,6 +9,8 @@ pitch: Central repository of threat modeling information, techniques, and method
 
 ---
 
+This is the maintained entry point for OWASP Threat Modeling Project resources. It connects current guidance, community references, tools, examples, and historical material while recognizing that there are various threat modeling methodologies.
+
 This is a documentation project. We provide information on threat modeling techniques for applications of all types, with a focus on current and emerging techniques.
 
 Most threat model techniques answer one or more of the following questions:


### PR DESCRIPTION
Clarify canonical entry point for OWASP Threat Modeling resources
Summary
This PR clarifies that the OWASP Threat Modeling Project page is the maintained entry point for Threat Modeling resources.
Why
Recent discussion showed that some historical Threat Modeling pages can be interpreted as current or normative OWASP guidance. This change helps visitors distinguish the maintained project landing page from historical or reference material.
Scope
This PR only clarifies positioning on the landing page. It does not introduce a new methodology, restructure the project, or change the status of historical resources.
Related discussion
Linked to: OWASP/www-project-threat-modeling#40