### PR TITLE
Add content status labels to Threat Modeling resources

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,6 +9,8 @@ pitch: Central repository of threat modeling information, techniques, and method
 
 ---
 
+> **Status:** Maintained Project Guidance
+
 This is a documentation project. We provide information on threat modeling techniques for applications of all types, with a focus on current and emerging techniques.
 
 Most threat model techniques answer one or more of the following questions:

--- a/resources/threat-severity-chart.md
+++ b/resources/threat-severity-chart.md
@@ -4,6 +4,8 @@ layout: col-sidebar
 tags: threatmodeling
 ---
 
+> **Status:** Reference Chart
+
 ## Threat Severity Classification Framework
 
 Adapted from the Microsoft SDL Bug Bar. This framework is used to triage and classify threats against our systems, services, and devices. Severity is assigned based on the nature of the threat, the context in which it can be triggered, and the degree of user interaction or authentication required.

--- a/tab_resources.md
+++ b/tab_resources.md
@@ -8,6 +8,8 @@ tags: threatmodeling
 
 ---
 
+> **Status:** Resource Index / Community References
+
 The best resource to start learning about threat modeling or improving your existing process, is the [Threat Modeling Manifesto](https://www.threatmodelingmanifesto.org/). This Manifesto was created by a group of leading threat modeling professionals.
 
 ## Reference Charts & Frameworks
@@ -30,9 +32,11 @@ The best resource to start learning about threat modeling or improving your exis
 
 ## Additional OWASP References
 
+These links include related OWASP project and community resources. Community pages may include historical material and should be read according to the status shown on those pages.
+
   - [Threat Modeling in OWASP Security Culture](https://owasp.org/www-project-security-culture/v10/6-Threat_Modelling/)
   - [Threat Modeling in OWASP Community Pages](https://owasp.org/www-community/Threat_Modeling)
-  - [Threat Modeling Process in OWASP Community Pages](https://owasp.org/www-community/Threat_Modeling_Process)
+  - [Threat Modeling Process in OWASP Community Pages (historical)](https://owasp.org/www-community/Threat_Modeling_Process)
   - [Threat Modeling at the OWASP DevSecOps Guideline Project](https://owasp.org/www-project-devsecops-guideline/latest/00b-Threat-modeling)
 
 

--- a/tab_resources.md
+++ b/tab_resources.md
@@ -32,7 +32,8 @@ The best resource to start learning about threat modeling or improving your exis
 
 ## Additional OWASP References
 
-These links include related OWASP project and community resources. Community pages may include historical material and should be read according to the status shown on those pages.
+These links include related OWASP project and community resources.
+Some of these pages may include historical material and should be read according to this status shown below.
 
   - [Threat Modeling in OWASP Security Culture](https://owasp.org/www-project-security-culture/v10/6-Threat_Modelling/)
   - [Threat Modeling in OWASP Community Pages](https://owasp.org/www-community/Threat_Modeling)


### PR DESCRIPTION
## Summary

This PR adds lightweight content status labels to selected OWASP Threat Modeling Project resources.

## Why

Recent discussion showed that visitors can confuse maintained project guidance, resource indexes, community references, and historical material. These labels make the status of selected content easier to understand without restructuring the project.

## Scope

This PR starts small by labeling:

- the main project landing page as maintained project guidance
- the resources tab as a resource index / community reference list
- the threat severity chart as a reference chart

It also marks the linked OWASP Community Threat Modeling Process page as historical in the resources list.

## Non-goals

This PR does not introduce a full content lifecycle system, restructure the site, or change the status of external pages.

## Related discussion

Linked to: OWASP/www-project-threat-modeling#40