### PR TITLE
Clarify methodology-neutral positioning of OWASP Threat Modeling

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,6 +22,12 @@ This project will gather techniques, methodologies, tools and examples. We will 
 
 Example: if you are looking for different diagramming techniques you will want to look for all the techniques answering the question "What are we working on."
 
+### Methodology-neutral positioning
+
+The OWASP Threat Modeling Project does not define a single official OWASP threat modeling methodology. The project supports a range of approaches, including STRIDE, PASTA, LINDDUN, attack trees, abuse cases, and other community practices.
+
+Different methods may be appropriate depending on system context, security and privacy goals, team maturity, delivery model, and regulatory needs. Contributions should explain their scope, assumptions, and intended use so practitioners can choose and adapt approaches responsibly.
+
 ### Guiding principles:
 
 This project follows a number of principles that all contributions must adhere to:

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ Example: if you are looking for different diagramming techniques you will want t
 
 ### Methodology-neutral positioning
 
-The OWASP Threat Modeling Project does not define a single official OWASP threat modeling methodology. The project supports a range of approaches, including STRIDE, PASTA, LINDDUN, attack trees, abuse cases, and other community practices.
+The OWASP Threat Modeling Project does not define a single official OWASP threat modeling methodology. The project documents a wide range of approaches, including STRIDE, PASTA, LINDDUN, attack trees, abuse cases, and other community practices.
 
 Different methods may be appropriate depending on system context, security and privacy goals, team maturity, delivery model, and regulatory needs. Contributions should explain their scope, assumptions, and intended use so practitioners can choose and adapt approaches responsibly.
 


### PR DESCRIPTION
Summary
This PR clarifies that the OWASP Threat Modeling Project is methodology-neutral and does not define a single official OWASP threat modeling methodology.

Why
The project should support a broad threat modeling ecosystem without implying that one method is canonical for OWASP or universally applicable.

Scope
This PR adds a short methodology-neutral positioning section to the project landing page. It names examples of approaches such as STRIDE, PASTA, LINDDUN, attack trees, and abuse cases, and asks contributors to explain scope, assumptions, and intended use.

Non-goals
This PR does not compare methodologies, endorse one approach over another, restructure the project, or change historical resources.

Related discussion
Linked to: OWASP/www-project-threat-modeling#40