### PR TITLE
Add Threat Modeling ecosystem navigation section

### DIFF
--- a/tab_resources.md
+++ b/tab_resources.md
@@ -10,6 +10,16 @@ tags: threatmodeling
 
 The best resource to start learning about threat modeling or improving your existing process, is the [Threat Modeling Manifesto](https://www.threatmodelingmanifesto.org/). This Manifesto was created by a group of leading threat modeling professionals.
 
+## Ecosystem Navigation
+
+Use this page as a map across threat modeling resources:
+
+- Tools and project guidance: OWASP projects listed below, including modeling tools, libraries, playbooks, and AI-assisted tooling.
+- Reference charts and frameworks: classification aids such as the Threat Severity Chart.
+- Related OWASP guidance: community pages, Security Culture, and DevSecOps guidance.
+- External references: books, process guidance, and practice material from the wider threat modeling community.
+- Future ecosystem areas: examples, benchmarks, interoperability formats, and reference architectures can be added as they become available.
+
 ## Reference Charts & Frameworks
 
 - [Threat Severity Chart](resources/threat-severity-chart)


### PR DESCRIPTION
Summary
This PR adds a lightweight ecosystem navigation section to the Threat Modeling resources page.

Why
The Threat Modeling Project is evolving toward an umbrella-style resource hub. A short navigation map helps visitors understand how existing resources fit together without restructuring the whole project.

Scope
This PR adds a small section that points readers toward:

tools and project guidance
reference charts and frameworks
related OWASP guidance
external community references
future ecosystem areas such as examples, benchmarks, interoperability formats, and reference architectures
Non-goals
This PR does not reorganize the existing resource list, introduce a new methodology, or add a full catalog/governance model.

Related discussion
Linked to: OWASP/www-project-threat-modeling#40